### PR TITLE
Use JMH for benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+*~
+target
+.idea
+*.iml
+settings.xml
+.classpath.txt
+.fullclasspath.txt
+
+# eclipse
+.project
+.buildpath
+.classpath
+.settings

--- a/common/src/main/java/yk/yast/common/utils/GaugeTester.java
+++ b/common/src/main/java/yk/yast/common/utils/GaugeTester.java
@@ -2,7 +2,9 @@ package yk.yast.common.utils;
 
 /**
  * Created by Yuri Kravchik on 08.12.2018
+ * @deprecated JMH should be used instead (see ubenchmark module)
  */
+@Deprecated
 public class GaugeTester {
     private StopWatchNs wholeTime;
     private StopWatchNs firstCall;

--- a/kotlinJetBrains/src/main/java/yk/yast/kotlin/intellij/IntelliJParser.kt
+++ b/kotlinJetBrains/src/main/java/yk/yast/kotlin/intellij/IntelliJParser.kt
@@ -1,0 +1,55 @@
+package yk.yast.kotlin.intellij
+
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.vfs.local.CoreLocalFileSystem
+import com.intellij.psi.PsiManager
+import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.psi.*
+import yk.yast.common.Words
+import yk.yast.common.YastNode
+import java.io.File
+
+public class IntelliJParser {
+    private val proj by lazy {
+        KotlinCoreEnvironment.createForProduction(
+                Disposer.newDisposable(),
+                CompilerConfiguration(),
+                EnvironmentConfigFiles.JVM_CONFIG_FILES
+        ).project
+    }
+    val fileSystem = CoreLocalFileSystem()
+
+    public fun parse(fileName: String): YastNode {
+        val file = fileSystem.findFileByIoFile(File(fileName))!!
+        val ktFile = PsiManager.getInstance(proj).findFile(file) as KtFile
+        return convert(ktFile) as YastNode
+    }
+
+    private fun convert(e: Any?): Any? {
+        if (e == null) return null;
+        //println(e::class.simpleName)
+        if (e is KtFile) {
+            return YastNode.node(Words.FILE, Words.MEMBERS, convertList(e.declarations))
+        } else if (e is KtClass) {
+            return YastNode.node(Words.CLASS_DEF, Words.NAME, e.name, Words.MEMBERS, convertList(e.declarations))
+        } else if (e is KtProperty) {
+            return YastNode.node(Words.NEW_VAR, Words.NAME, e.name)
+        } else if (e is KtNamedFunction) {
+            return YastNode.node(Words.METHOD_DEF, Words.NAME, e.name, Words.PARAMETERS, convertList(e.valueParameters), Words.BODY, convert(e.bodyExpression));
+        } else if (e is KtBlockExpression) {
+            return YastNode.node(Words.BLOCK, Words.STATEMENTS, convertList(e.statements));
+        }
+        return YastNode.node(Words.VALUE, Words.VALUE, e::class.simpleName)
+    }
+
+    private fun convertList(e: List<Any?>): Any {
+        //println(e.size)
+        val result: MutableCollection<Any?> = ArrayList()
+        for (t in e) {
+            result.add(convert(t))
+        }
+        return result
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <module>kotlin</module>
         <module>kotlinAntlr</module><!--TODO get rid-->
         <module>kotlinJetBrains</module><!--TODO get rid-->
+        <module>ubenchmark</module>
 
     </modules>
 
@@ -23,6 +24,8 @@
 
     <properties>
         <kotlin.version>1.2.71</kotlin.version>
+        <javac.source>1.8</javac.source>
+        <javac.target>1.8</javac.target>
     </properties>
 
     <dependencies>

--- a/ubenchmark/README.md
+++ b/ubenchmark/README.md
@@ -1,0 +1,15 @@
+# yast benchmarks
+
+This module contains JMH benchmarks for the parsers
+
+Note: you'd better shut down all the applications and connect notebook to the power for reproducible results.
+
+Random results from Java 1.8, 2,6 GHz Intel Core i7
+
+```
+Benchmark                                     Mode  Cnt      Score      Error   Units
+ParserBenchmark.intellij                      avgt    7     17,497 ±    0,251   us/op
+ParserBenchmark.intellij:·gc.alloc.rate.norm  avgt    7   8968,534 ±    0,035    B/op
+ParserBenchmark.javacc                        avgt    7     67,014 ±    3,684   us/op
+ParserBenchmark.javacc:·gc.alloc.rate.norm    avgt    7  44435,278 ±   19,359    B/op
+```

--- a/ubenchmark/pom.xml
+++ b/ubenchmark/pom.xml
@@ -1,0 +1,220 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>yk.yast</groupId>
+        <artifactId>yast</artifactId>
+        <version>0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>ubenchmark</artifactId>
+    <name>JMH benchmarks</name>
+
+    <properties>
+        <jmh.version>1.20</jmh.version>
+        <jmh.generator>default</jmh.generator>
+    </properties>
+
+    <build>
+        <plugins>
+            <!--
+                1. Compile Kotlin sources first.
+            -->
+
+            <plugin>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <!--
+                   Put an appropriate Kotlin compiler version here.
+                 -->
+                <version>${kotlin.version}</version>
+
+                <configuration>
+                    <args>
+                        <!--<arg>-Xno-inline</arg>-->
+                    </args>
+                </configuration>
+
+                <executions>
+                    <execution>
+                        <id>process-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!--
+                2. Invoke JMH generators to produce benchmark code
+            -->
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.2.1</version>
+                <executions>
+                    <execution>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <includePluginDependencies>true</includePluginDependencies>
+                            <mainClass>org.openjdk.jmh.generators.bytecode.JmhBytecodeGenerator</mainClass>
+                            <arguments>
+                                <argument>${project.basedir}/target/classes/</argument>
+                                <argument>${project.basedir}/target/generated-sources/jmh/</argument>
+                                <argument>${project.basedir}/target/classes/</argument>
+                                <argument>${jmh.generator}</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.openjdk.jmh</groupId>
+                        <artifactId>jmh-generator-bytecode</artifactId>
+                        <version>${jmh.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
+            <!--
+                3. Add JMH generated code to the compile session.
+            -->
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.basedir}/target/generated-sources/jmh</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!--
+                4. Compile JMH generated code.
+             -->
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <compilerVersion>${javac.target}</compilerVersion>
+                    <source>${javac.target}</source>
+                    <target>${javac.target}</target>
+                    <compilerArgument>-proc:none</compilerArgument>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>compile-sources</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>compile-all</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!--
+                5. Package all the dependencies into the JAR
+             -->
+
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>ubenchmarks</finalName>
+                            <filters>
+                                <filter>
+                                    <!--
+                                        Exclude files that sign a jar
+                                        (one or multiple of the dependencies).
+                                        One may not repack a signed jar without
+                                        this, or you will get a
+                                        SecurityException at program start.
+                                    -->
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/*.INF</exclude> <!-- This one may not be required -->
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>yk.yast</groupId>
+            <artifactId>kotlin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>yk.yast</groupId>
+            <artifactId>kotlinJetBrains</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>provided</scope>
+            <version>${jmh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-compiler</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/ubenchmark/src/main/kotlin/yk/yast/kotlin/benchmark/ParserBenchmark.kt
+++ b/ubenchmark/src/main/kotlin/yk/yast/kotlin/benchmark/ParserBenchmark.kt
@@ -1,0 +1,47 @@
+package yk.yast.kotlin.benchmark
+
+import org.openjdk.jmh.annotations.*
+import org.openjdk.jmh.profile.GCProfiler
+import org.openjdk.jmh.runner.Runner
+import org.openjdk.jmh.runner.options.OptionsBuilder
+import yk.kotlin.gen.KotlinParser
+import yk.yast.common.YastNode
+import yk.yast.kotlin.intellij.IntelliJParser
+import java.io.ByteArrayInputStream
+import java.io.FileInputStream
+import java.util.concurrent.TimeUnit
+
+@Fork(value = 1, jvmArgsPrepend = ["-Xmx128m"])
+@Measurement(iterations = 7, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 7, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Threads(1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+open class ParserBenchmark {
+    val fileName = "kotlin/src/test/resources/SimpleClass.kt"
+
+    val intellijParser = IntelliJParser()
+
+    val javaccParser = KotlinParser(ByteArrayInputStream(ByteArray(0)))
+
+    @Benchmark
+    fun intellij(): YastNode = intellijParser.parse(fileName)
+
+    @Benchmark
+    fun javacc(): YastNode =
+            FileInputStream(fileName).use {
+                javaccParser.ReInit(it)
+                javaccParser.File()
+            }
+}
+
+fun main(args: Array<String>) {
+    println(ParserBenchmark::class.java.simpleName)
+    val options = OptionsBuilder()
+            .include(ParserBenchmark::class.java.simpleName)
+            .addProfiler(GCProfiler::class.java)
+            .detectJvmArgs()
+            .build()
+    Runner(options).run()
+}


### PR DESCRIPTION
1) Lots of benchmark frameworks are broken for various reasons, so `yk.yast.common.utils.GaugeTester` must never be used.

2) `GaugeKotlinIntellijParser` re-creates `KotlinCoreEnvironment` and `Project` for each parse which makes absolutely no sense. Environment should be reused.
 https://github.com/kravchik/yast/blob/e7cb8ccce2e3edb0c992f1dceba02d83dc72f1b5/kotlinJetBrains/src/main/java/yk/yast/kotlin/intellij/GaugeKotlinIntellijParser.kt#L27-L35

Here's overall result: InteliJ is 4 times faster.

```
Benchmark                     Mode  Cnt      Score      Error   Units
intellij                      avgt    7     17,497 ±    0,251   us/op
intellij:·gc.alloc.rate.norm  avgt    7   8968,534 ±    0,035    B/op
javacc                        avgt    7     67,014 ±    3,684   us/op
javacc:·gc.alloc.rate.norm    avgt    7  44435,278 ±   19,359    B/op
```
